### PR TITLE
fix scrolling issue

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { getAuth, onAuthStateChanged, signOut } from "firebase/auth";
 import Login from "./components/Login";
 import Home from "./components/Home";
@@ -9,6 +9,19 @@ import Judge from "./components/Judge";
 import Legislation from "./components/Legislation";
 import PublicTranscriptView from "./components/PublicTranscriptView";
 
+// Component to handle scroll reset on route changes
+function ScrollToTop() {
+  const location = useLocation();
+  
+  useEffect(() => {
+    // Force scroll to top on route change with multiple methods
+    window.scrollTo(0, 0);
+    document.documentElement.scrollTop = 0;
+    document.body.scrollTop = 0;
+  }, [location.pathname]);
+  
+  return null;
+}
 
 function App() {
   const [user, setUser] = useState(null);
@@ -65,7 +78,8 @@ function App() {
   }
 
   return (
-    <Router>
+    <Router future={{ v7_startTransition: true }}>
+      <ScrollToTop />
       <Routes>
         {/* Public route for shared transcripts - accessible without login */}
         <Route path="/shared/:shareId" element={<PublicTranscriptView />} />

--- a/frontend/src/components/Debate.jsx
+++ b/frontend/src/components/Debate.jsx
@@ -88,6 +88,16 @@ function Debate() {
     navigate("/debatesim");
   };
 
+  // Reset scroll position on component mount
+  useEffect(() => {
+    // Force scroll reset with slight delay to ensure it works after navigation
+    const scrollTimer = setTimeout(() => {
+      window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+    }, 0);
+    
+    return () => clearTimeout(scrollTimer);
+  }, []);
+
   // Cleanup auto timer on unmount
   useEffect(() => {
     return () => {

--- a/frontend/src/components/DebateSim.jsx
+++ b/frontend/src/components/DebateSim.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useLayoutEffect, useRef } from "react";
 import { getFirestore, collection, getDocs, query, orderBy } from "firebase/firestore";
 import { auth } from "../firebase/firebaseConfig";
 import { signOut, getAuth } from "firebase/auth";
@@ -38,10 +38,19 @@ function DebateSim({ user }) {
   const inputRef = useRef(null);
   const pdfContentRef = useRef(null);
 
+  // Immediate scroll reset using useLayoutEffect
+  useLayoutEffect(() => {
+    // Multiple scroll reset methods to ensure it works
+    window.scrollTo(0, 0);
+    document.documentElement.scrollTop = 0;
+    document.body.scrollTop = 0;
+  }, []);
+
   // Animation trigger
   useEffect(() => {
-    const timer = setTimeout(() => setIsVisible(true), 100);
-    return () => clearTimeout(timer);
+    // Start animations after a brief delay
+    const animationTimer = setTimeout(() => setIsVisible(true), 100);
+    return () => clearTimeout(animationTimer);
   }, []);
 
   // Fetch history on load

--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -26,9 +26,18 @@ function Home({ user, onLogout }) {
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
+    // Force scroll reset with slight delay to ensure it works after navigation
+    const scrollTimer = setTimeout(() => {
+      window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+    }, 0);
+    
     // Trigger animations on mount
-    const timer = setTimeout(() => setIsVisible(true), 100);
-    return () => clearTimeout(timer);
+    const animationTimer = setTimeout(() => setIsVisible(true), 100);
+    
+    return () => {
+      clearTimeout(scrollTimer);
+      clearTimeout(animationTimer);
+    };
   }, []);
 
   const handleLogout = () => {
@@ -102,7 +111,12 @@ function Home({ user, onLogout }) {
 
   const handleFeatureClick = (feature) => {
     if (feature.status === "coming-soon") return;
-    navigate(feature.route);
+    
+    // Force immediate scroll reset before navigation
+    document.documentElement.scrollTop = 0;
+    document.body.scrollTop = 0;
+    
+    navigate(feature.route, { replace: false, state: { scrollReset: true } });
   };
 
   return (

--- a/frontend/src/components/Judge.jsx
+++ b/frontend/src/components/Judge.jsx
@@ -32,6 +32,15 @@ function Judge() {
   // Extract bill description from transcript
   const [billDescription, setBillDescription] = useState("");
   
+  // Reset scroll position on component mount
+  useEffect(() => {
+    // Force scroll reset with slight delay to ensure it works after navigation
+    const scrollTimer = setTimeout(() => {
+      window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+    }, 0);
+    
+    return () => clearTimeout(scrollTimer);
+  }, []);
 
   useEffect(() => {
     // Extract bill description from transcript if it exists

--- a/frontend/src/components/Legislation.jsx
+++ b/frontend/src/components/Legislation.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getAuth, signOut } from 'firebase/auth';
 import { getFirestore, collection, getDocs, query, orderBy } from "firebase/firestore";
@@ -349,6 +349,14 @@ const Legislation = ({ user }) => {
       console.error("Error fetching debate history:", err);
     }
   };
+
+  // Immediate scroll reset using useLayoutEffect
+  useLayoutEffect(() => {
+    // Multiple scroll reset methods to ensure it works
+    window.scrollTo(0, 0);
+    document.documentElement.scrollTop = 0;
+    document.body.scrollTop = 0;
+  }, []);
 
   // Fetch debate history on component mount
   useEffect(() => {

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -54,6 +54,16 @@ function Login({ onLogin }) {
     }
   };
 
+  // Scroll reset on component mount
+  useEffect(() => {
+    // Force scroll reset with slight delay to ensure it works after navigation
+    const scrollTimer = setTimeout(() => {
+      window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+    }, 0);
+    
+    return () => clearTimeout(scrollTimer);
+  }, []);
+
   // Typing animation effect
   useEffect(() => {
     const typeText = () => {


### PR DESCRIPTION
## Summary by Sourcery

Reset scroll to top across navigation and component mounts to fix residual scroll positions

Bug Fixes:
- Ensure window scroll resets to top when navigating between features in Home

Enhancements:
- Introduce ScrollToTop component to automatically reset scroll on route changes
- Add useEffect/useLayoutEffect hooks in Home, DebateSim, Debate, Login, Judge, and Legislation to force scroll to top on mount
- Enhance Home navigation to reset scroll immediately before navigation and pass scrollReset state
- Enable React Router future v7 startTransition flag in Router configuration