### PR TITLE
fix feature hub scroll should only exist if not enough space for all …

### DIFF
--- a/frontend/src/components/Home.css
+++ b/frontend/src/components/Home.css
@@ -90,7 +90,7 @@
 .home-main-content {
   flex: 1 !important;
   width: 100% !important;
-  max-width: 1000px !important;
+  max-width: 1800px !important;
   margin: 0 auto !important;
   display: flex !important;
   flex-direction: column !important;
@@ -221,9 +221,9 @@
 .home-features-container {
   position: relative !important;
   width: 100% !important;
-  max-width: 1200px !important;
-  padding: 0 30px !important;
-  margin: 2rem 0 !important;
+  max-width: 1600px !important;
+  padding: 0 60px !important;
+  margin: 1.5rem 0 !important;
 }
 
 .home-scroll-arrow {
@@ -277,11 +277,18 @@
   gap: 2rem !important;
   width: 100% !important;
   overflow-x: auto !important;
-  overflow-y: hidden !important;
-  padding-bottom: 1.5rem !important;
+  overflow-y: visible !important;
+  padding: 1rem 0 1.5rem 0 !important;
   scrollbar-width: none !important;
   scroll-behavior: smooth !important;
   -ms-overflow-style: none !important;
+}
+
+/* Center cards when there's enough space (no scrolling needed) */
+@media (min-width: 1400px) {
+  .home-feature-cards {
+    justify-content: center !important;
+  }
 }
 
 .home-feature-cards::-webkit-scrollbar {

--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -51,6 +51,18 @@ function Home({ user, onLogout }) {
     if (!container) return;
     
     const { scrollLeft, scrollWidth, clientWidth } = container;
+    
+    // Only show arrows if there's actually overflow (more content than visible area)
+    const hasOverflow = scrollWidth > clientWidth + 10; // Add small buffer
+    
+    if (!hasOverflow) {
+      // Reset scroll position when there's no overflow
+      container.scrollLeft = 0;
+      setShowLeftArrow(false);
+      setShowRightArrow(false);
+      return;
+    }
+    
     const isAtStart = scrollLeft <= 5; // Small tolerance for floating point precision
     const isAtEnd = scrollLeft >= scrollWidth - clientWidth - 5; // Small tolerance
     
@@ -62,7 +74,7 @@ function Home({ user, onLogout }) {
     const container = featureCardsRef.current;
     if (!container) return;
     
-    const scrollAmount = 350;
+    const scrollAmount = 370; // Increased to account for gaps
     container.scrollBy({ 
       left: direction === 'left' ? -scrollAmount : scrollAmount, 
       behavior: 'smooth' 
@@ -75,7 +87,13 @@ function Home({ user, onLogout }) {
 
     const handleScroll = () => updateArrowVisibility();
     const handleResize = () => {
-      setTimeout(() => updateArrowVisibility(), 100);
+      // Force a reflow to ensure accurate measurements
+      setTimeout(() => {
+        if (container) {
+          container.scrollLeft = container.scrollLeft; // Force reflow
+          updateArrowVisibility();
+        }
+      }, 100);
     };
 
     container.addEventListener('scroll', handleScroll);

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -86,6 +86,18 @@ function Login({ onLogin }) {
     if (!container) return;
     
     const { scrollLeft, scrollWidth, clientWidth } = container;
+    
+    // Only show arrows if there's actually overflow (more content than visible area)
+    const hasOverflow = scrollWidth > clientWidth;
+    
+    if (!hasOverflow) {
+      // Reset scroll position when there's no overflow
+      container.scrollLeft = 0;
+      setShowLeftArrow(false);
+      setShowRightArrow(false);
+      return;
+    }
+    
     const isAtStart = scrollLeft <= 5; // Small tolerance for floating point precision
     const isAtEnd = scrollLeft >= scrollWidth - clientWidth - 5; // Small tolerance
     
@@ -165,7 +177,13 @@ function Login({ onLogin }) {
 
     const handleScroll = () => updateArrowVisibility();
     const handleResize = () => {
-      setTimeout(() => updateArrowVisibility(), 100);
+      // Force a reflow to ensure accurate measurements
+      setTimeout(() => {
+        if (container) {
+          container.scrollLeft = container.scrollLeft; // Force reflow
+          updateArrowVisibility();
+        }
+      }, 100);
     };
 
     container.addEventListener('scroll', handleScroll);


### PR DESCRIPTION
…3 cards (copy login.jsx scroll mech). closes #221

## Summary by Sourcery

Display scroll arrows only when feature carousels overflow, refine scroll behavior on resize, and improve layout spacing and centering for feature hubs

Bug Fixes:
- Only show scroll arrows when carousel content overflows and reset scroll/arrow state when not

Enhancements:
- Force a reflow on resize for accurate arrow visibility and increase scroll step for feature hub
- Revise Home layout CSS to expand max widths, adjust padding/margins, make overflow-y visible, and center feature cards on large screens via media query