### PR TITLE
fix circle size for bill grades

### DIFF
--- a/frontend/src/components/HistorySidebar.jsx
+++ b/frontend/src/components/HistorySidebar.jsx
@@ -77,8 +77,8 @@ const GradeItem = ({ label, percentage, description, tooltip, icon, category, is
       </div>
       <CircularProgress 
         percentage={percentage} 
-        size={isOverall ? 90 : 75}
-        strokeWidth={isOverall ? 8 : 6}
+        size={isOverall ? 90 : 90}
+        strokeWidth={isOverall ? 8 : 8}
         color={gradeColor}
       />
       <div className="grade-description">{description}</div>
@@ -97,7 +97,7 @@ const BillGradingSection = ({ grades }) => {
     economicImpact: {
       label: 'Economic Impact',
       description: 'Fiscal responsibility & benefits',
-      tooltip: 'Evaluates the bill\'s economic benefits, cost-effectiveness, and fiscal impact on government budgets and the economy.',
+      tooltip: 'Economic benefits and fiscal impact',
       icon: '💰',
       category: 'moderate',
       order: 1
@@ -105,7 +105,7 @@ const BillGradingSection = ({ grades }) => {
     publicBenefit: {
       label: 'Public Benefit',
       description: 'Benefits to citizens',
-      tooltip: 'Assesses how much the bill addresses public needs and benefits different segments of the population.',
+      tooltip: 'Addresses public needs effectively',
       icon: '👥',
       category: 'positive',
       order: 2
@@ -113,7 +113,7 @@ const BillGradingSection = ({ grades }) => {
     feasibility: {
       label: 'Implementation Feasibility',
       description: 'Practicality of execution',
-      tooltip: 'Examines whether the bill can be realistically implemented with available resources and existing infrastructure.',
+      tooltip: 'Can be realistically implemented',
       icon: '🛠',
       category: 'caution',
       order: 3
@@ -121,7 +121,7 @@ const BillGradingSection = ({ grades }) => {
     legalSoundness: {
       label: 'Legal Soundness',
       description: 'Constitutional compliance',
-      tooltip: 'Reviews the bill\'s compliance with constitutional principles and existing legal frameworks.',
+      tooltip: 'Constitutional and legal compliance',
       icon: '⚖️',
       category: 'positive',
       order: 4
@@ -129,7 +129,7 @@ const BillGradingSection = ({ grades }) => {
     effectiveness: {
       label: 'Goal Effectiveness',
       description: 'Achievement of stated objectives',
-      tooltip: 'Measures how well the bill addresses its stated problems and achieves its intended objectives.',
+      tooltip: 'Achieves stated objectives well',
       icon: '🎯',
       category: 'moderate',
       order: 5
@@ -137,7 +137,7 @@ const BillGradingSection = ({ grades }) => {
     overall: {
       label: 'Overall Rating',
       description: 'Comprehensive assessment',
-      tooltip: 'A weighted average of all criteria with emphasis on effectiveness and public benefit.',
+      tooltip: 'Weighted average of all criteria',
       icon: '📊',
       category: 'overall',
       order: 6

--- a/frontend/src/components/Legislation.css
+++ b/frontend/src/components/Legislation.css
@@ -2971,8 +2971,8 @@
 
 .circular-progress {
   position: relative;
-  width: 75px;
-  height: 75px;
+  width: 90px;
+  height: 90px;
   margin: 1rem 0;
 }
 
@@ -3233,13 +3233,13 @@
   }
   
   .circular-progress {
-    width: 65px;
-    height: 65px;
+    width: 80px;
+    height: 80px;
   }
   
   .grade-item.overall .circular-progress {
-    width: 80px;
-    height: 80px;
+    width: 90px;
+    height: 90px;
   }
   
   .circular-progress .progress-text {
@@ -3306,8 +3306,8 @@
   }
   
   .circular-progress {
-    width: 70px;
-    height: 70px;
+    width: 75px;
+    height: 75px;
   }
   
   .grade-item.overall .circular-progress {

--- a/frontend/src/components/Legislation.jsx
+++ b/frontend/src/components/Legislation.jsx
@@ -120,8 +120,8 @@ const GradeItem = ({ label, percentage, description, tooltip, icon, category, is
       </div>
       <CircularProgress 
         percentage={percentage} 
-        size={isOverall ? 90 : 75}
-        strokeWidth={isOverall ? 8 : 6}
+        size={isOverall ? 90 : 90}
+        strokeWidth={isOverall ? 8 : 8}
         color={gradeColor}
       />
       <div className="grade-description">{description}</div>
@@ -140,7 +140,7 @@ const BillGradingSection = ({ grades }) => {
     economicImpact: {
       label: 'Economic Impact',
       description: 'Fiscal responsibility & benefits',
-      tooltip: 'Evaluates the bill\'s economic benefits, cost-effectiveness, and fiscal impact on government budgets and the economy.',
+      tooltip: 'Economic benefits and fiscal impact',
       icon: '💰',
       category: 'moderate',
       order: 1
@@ -148,7 +148,7 @@ const BillGradingSection = ({ grades }) => {
     publicBenefit: {
       label: 'Public Benefit',
       description: 'Benefits to citizens',
-      tooltip: 'Assesses how much the bill addresses public needs and benefits different segments of the population.',
+      tooltip: 'Addresses public needs effectively',
       icon: '👥',
       category: 'positive',
       order: 2
@@ -156,7 +156,7 @@ const BillGradingSection = ({ grades }) => {
     feasibility: {
       label: 'Implementation Feasibility',
       description: 'Practicality of execution',
-      tooltip: 'Examines whether the bill can be realistically implemented with available resources and existing infrastructure.',
+      tooltip: 'Can be realistically implemented',
       icon: '🛠',
       category: 'caution',
       order: 3
@@ -164,7 +164,7 @@ const BillGradingSection = ({ grades }) => {
     legalSoundness: {
       label: 'Legal Soundness',
       description: 'Constitutional compliance',
-      tooltip: 'Reviews the bill\'s compliance with constitutional principles and existing legal frameworks.',
+      tooltip: 'Constitutional and legal compliance',
       icon: '⚖️',
       category: 'positive',
       order: 4
@@ -172,7 +172,7 @@ const BillGradingSection = ({ grades }) => {
     effectiveness: {
       label: 'Goal Effectiveness',
       description: 'Achievement of stated objectives',
-      tooltip: 'Measures how well the bill addresses its stated problems and achieves its intended objectives.',
+      tooltip: 'Achieves stated objectives well',
       icon: '🎯',
       category: 'moderate',
       order: 5
@@ -180,7 +180,7 @@ const BillGradingSection = ({ grades }) => {
     overall: {
       label: 'Overall Rating',
       description: 'Comprehensive assessment',
-      tooltip: 'A weighted average of all criteria with emphasis on effectiveness and public benefit.',
+      tooltip: 'Weighted average of all criteria',
       icon: '📊',
       category: 'overall',
       order: 6

--- a/frontend/src/components/PublicTranscriptView.css
+++ b/frontend/src/components/PublicTranscriptView.css
@@ -214,7 +214,7 @@
 .public-transcript-footer {
   text-align: center;
   padding: 2rem;
-  background: white;
+  background: rgba(0, 0, 0, 0.457);
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }

--- a/frontend/src/components/PublicTranscriptView.jsx
+++ b/frontend/src/components/PublicTranscriptView.jsx
@@ -101,8 +101,8 @@ const GradeItem = ({ label, percentage, description, tooltip, icon, category, is
       </div>
       <CircularProgress 
         percentage={percentage} 
-        size={isOverall ? 90 : 75}
-        strokeWidth={isOverall ? 8 : 6}
+        size={isOverall ? 90 : 90}
+        strokeWidth={isOverall ? 8 : 8}
         color={gradeColor}
       />
       <div className="grade-description">{description}</div>
@@ -120,7 +120,7 @@ const BillGradingSection = ({ grades }) => {
     economicImpact: {
       label: 'Economic Impact',
       description: 'Fiscal responsibility & benefits',
-      tooltip: 'Evaluates the bill\'s economic benefits, cost-effectiveness, and fiscal impact on government budgets and the economy.',
+      tooltip: 'Economic benefits and fiscal impact',
       icon: '💰',
       category: 'moderate',
       order: 1
@@ -128,7 +128,7 @@ const BillGradingSection = ({ grades }) => {
     publicBenefit: {
       label: 'Public Benefit', 
       description: 'Benefits to citizens',
-      tooltip: 'Assesses how much the bill addresses public needs and benefits different segments of the population.',
+      tooltip: 'Addresses public needs effectively',
       icon: '👥',
       category: 'positive',
       order: 2
@@ -136,7 +136,7 @@ const BillGradingSection = ({ grades }) => {
     feasibility: {
       label: 'Implementation Feasibility',
       description: 'Practicality of execution',
-      tooltip: 'Examines whether the bill can be realistically implemented with available resources and existing infrastructure.',
+      tooltip: 'Can be realistically implemented',
       icon: '🛠',
       category: 'caution',
       order: 3
@@ -144,7 +144,7 @@ const BillGradingSection = ({ grades }) => {
     legalSoundness: {
       label: 'Legal Soundness',
       description: 'Constitutional compliance',
-      tooltip: 'Reviews the bill\'s compliance with constitutional principles and existing legal frameworks.',
+      tooltip: 'Constitutional and legal compliance',
       icon: '⚖️',
       category: 'positive',
       order: 4
@@ -152,7 +152,7 @@ const BillGradingSection = ({ grades }) => {
     effectiveness: {
       label: 'Goal Effectiveness',
       description: 'Achievement of stated objectives',
-      tooltip: 'Measures how well the bill addresses its stated problems and achieves its intended objectives.',
+      tooltip: 'Achieves stated objectives well',
       icon: '🎯',
       category: 'moderate',
       order: 5
@@ -160,7 +160,7 @@ const BillGradingSection = ({ grades }) => {
     overall: {
       label: 'Overall Rating',
       description: 'Comprehensive assessment',
-      tooltip: 'A weighted average of all criteria with emphasis on effectiveness and public benefit.',
+      tooltip: 'Weighted average of all criteria',
       icon: '📊',
       category: 'overall',
       order: 6


### PR DESCRIPTION
## Summary by Sourcery

Standardize circular progress visuals for bill grades by unifying sizes and stroke widths across components, simplify grading tooltips, adjust related CSS dimensions, and update the public transcript footer background to a semi-transparent style.

Bug Fixes:
- Fix inconsistent circular progress dimensions for bill grade items across HistorySidebar, Legislation, and PublicTranscriptView

Enhancements:
- Simplify tooltip text for each grading criterion to concise phrases
- Adjust CSS circular-progress selectors to use the new uniform dimensions
- Change public transcript footer background from white to semi-transparent black