### PR TITLE
fix headers and pages. closes #377

### DIFF
--- a/frontend/src/components/History.jsx
+++ b/frontend/src/components/History.jsx
@@ -254,6 +254,10 @@ function History({ user, onLogout }) {
     if (filterType !== "all") {
       filtered = filtered.filter(item => {
         const itemType = getActivityType(item);
+        if (filterType === "bill") {
+          // Only show Bill Debate, not Analyze Bill
+          return itemType === 'Bill Debate';
+        }
         return itemType.toLowerCase().includes(filterType.toLowerCase());
       });
     }

--- a/frontend/src/components/Judge.jsx
+++ b/frontend/src/components/Judge.jsx
@@ -278,14 +278,6 @@ ${feedback}`;
       <header className="judge-header">
         <div className="judge-header-content">
           <div className="judge-header-left">
-            <button 
-              className="judge-history-button"
-              onClick={() => navigate("/")}
-              title="Go to Home"
-            >
-              <History size={18} />
-              <span>Home</span>
-            </button>
           </div>
 
           <div className="judge-header-center" style={{


### PR DESCRIPTION
## Summary by Sourcery

Remove redundant home navigation button from the judge header and refine the history filter so that selecting “bill” only shows debate activities.

Bug Fixes:
- Remove the “Home” button from the judge page header
- Restrict the “bill” filter in History to only show Bill Debate entries